### PR TITLE
Bs mapping validations

### DIFF
--- a/elastic_model.gemspec
+++ b/elastic_model.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "rspec-mocks"
+  spec.add_development_dependency "rspec-mocks", "~> 3.0"
   spec.add_development_dependency "mocha", "0.9.8"
   spec.add_development_dependency "bourne"
   spec.add_development_dependency "awesome_print"

--- a/lib/elastic_model.rb
+++ b/lib/elastic_model.rb
@@ -5,6 +5,7 @@ require 'elasticsearch'
 require 'elastic_model/version'
 require 'elastic_model/instrumentation'
 require 'elastic_model/callbacks'
+require 'elastic_model/exceptions'
 
 # TODO: error out if host is not defined
 log = ENV['debug'] ? true : false

--- a/lib/elastic_model/exceptions.rb
+++ b/lib/elastic_model/exceptions.rb
@@ -1,0 +1,2 @@
+class MissingFieldException < Exception; end
+class MissingMappingException < Exception; end

--- a/lib/elastic_model/instrumentation.rb
+++ b/lib/elastic_model/instrumentation.rb
@@ -80,8 +80,8 @@ module ElasticModel::Instrumentation
     end
 
     def self.mapping_for(field_name, options = {})
-      symbolized_keys = self.new.as_json.keys.map(&:to_sym)
-      raise MissingFieldException unless symbolized_keys.include?(field_name.to_sym)
+      attribute_names = self.new.attribute_names
+      raise MissingFieldException unless attribute_names.include?(field_name.to_s)
 
       class_variable_get('@@es_mappings_var')[field_name] = options
     end
@@ -91,9 +91,8 @@ module ElasticModel::Instrumentation
     end
 
     def save_to_es!
-      symbolized_keys = self.as_json.keys.map(&:to_sym)
-      mapping_keys = self.class.class_variable_get('@@es_mappings_var').keys.map(&:to_sym)
-      raise MissingMappingException unless (symbolized_keys & mapping_keys).length == symbolized_keys.length
+      mapping_keys = self.class.class_variable_get('@@es_mappings_var').keys.map(&:to_s)
+      raise MissingMappingException unless (self.attribute_names & mapping_keys).length == self.attribute_names.length
 
       body   = self.as_json
       params = {

--- a/lib/elastic_model/instrumentation.rb
+++ b/lib/elastic_model/instrumentation.rb
@@ -122,6 +122,3 @@ module ElasticModel::Instrumentation
     end
   end
 end
-
-class MissingFieldException < Exception; end
-class MissingMappingException < Exception; end

--- a/lib/elastic_model/matchers.rb
+++ b/lib/elastic_model/matchers.rb
@@ -10,7 +10,7 @@ RSpec::Matchers.define :have_mapping_for do |field_name, hash|
     end
   end
 
-  failure_message_for_should do
+  failure_message do
     "#{@field_name} got: #{@mapping}, expected: #{@hash}"
   end
 end

--- a/lib/elastic_model/version.rb
+++ b/lib/elastic_model/version.rb
@@ -1,5 +1,5 @@
 puts __FILE__ if ENV['debug']
 
 module ElasticModel
-  VERSION = "0.1.2"
+  VERSION = "0.1"
 end

--- a/lib/elastic_model/version.rb
+++ b/lib/elastic_model/version.rb
@@ -1,5 +1,5 @@
 puts __FILE__ if ENV['debug']
 
 module ElasticModel
-  VERSION = "0.0.2"
+  VERSION = "0.1.2"
 end

--- a/spec/lib/elastic_model/integration/callbacks_spec.rb
+++ b/spec/lib/elastic_model/integration/callbacks_spec.rb
@@ -10,6 +10,9 @@ describe ElasticModel::Callbacks do
         create_es_index
 
         field :count, :type => Integer
+
+        mapping_for :count, { :type => 'integer' }
+        mapping_for :_id, { :type => 'string', :index => 'not_analyzed' }
       end
     end
     let(:test_instance) { test_class.new(:count => 1) }

--- a/spec/lib/elastic_model/integration/callbacks_spec.rb
+++ b/spec/lib/elastic_model/integration/callbacks_spec.rb
@@ -12,7 +12,7 @@ describe ElasticModel::Callbacks do
         field :count, :type => Integer
 
         mapping_for :count, { :type => 'integer' }
-        mapping_for :_id, { :type => 'string', :index => 'not_analyzed' }
+        mapping_for :_id,   { :type => 'string', :index => 'not_analyzed' }
       end
     end
     let(:test_instance) { test_class.new(:count => 1) }

--- a/spec/lib/elastic_model/integration/callbacks_with_parent_indices_spec.rb
+++ b/spec/lib/elastic_model/integration/callbacks_with_parent_indices_spec.rb
@@ -10,6 +10,8 @@ describe ElasticModel::Callbacks do
         es_index_name "test_classes"
         es_type "parent_test_type"
 
+        mapping_for :_id, { :type => 'string', :index => 'not_analyzed' }
+
         create_es_index
         create_es_mappings
       end
@@ -26,6 +28,10 @@ describe ElasticModel::Callbacks do
         field :count, :type => Integer
         belongs_to :parent_association
         es_index_name "test_classes"
+
+        mapping_for :_id, { :type => 'string', :index => 'not_analyzed' }
+        mapping_for :parent_association_id, { :type => 'string', :index => 'not_analyzed' }
+        mapping_for :count, { :type => 'integer' }
 
         create_es_index
         create_es_mappings
@@ -56,6 +62,10 @@ describe ElasticModel::Callbacks do
             :_routing => { :path => "parent_association_id" }
           })
 
+          mapping_for :_id, { :type => 'string', :index => 'not_analyzed' }
+          mapping_for :parent_association_id, { :type => 'string', :index => 'not_analyzed' }
+          mapping_for :count, { :type => 'integer' }
+
           create_es_index
           create_es_mappings
 
@@ -72,11 +82,16 @@ describe ElasticModel::Callbacks do
           include ElasticModel::Callbacks
           belongs_to :parent_association
 
+          field :count, :type => Integer
           es_index_name "test_classes"
           es_mapping_options({
             :_parent  => { :type => "parent_test_type" },
             :_routing => { :path => "parent_association_id", :required => false }
           })
+
+          mapping_for :_id, { :type => 'string', :index => 'not_analyzed' }
+          mapping_for :parent_association_id, { :type => 'string', :index => 'not_analyzed' }
+          mapping_for :count, { :type => 'integer' }
 
           create_es_index
           create_es_mappings

--- a/spec/lib/elastic_model/integration/callbacks_with_parent_indices_spec.rb
+++ b/spec/lib/elastic_model/integration/callbacks_with_parent_indices_spec.rb
@@ -29,9 +29,9 @@ describe ElasticModel::Callbacks do
         belongs_to :parent_association
         es_index_name "test_classes"
 
-        mapping_for :_id, { :type => 'string', :index => 'not_analyzed' }
+        mapping_for :_id,                   { :type => 'string', :index => 'not_analyzed' }
         mapping_for :parent_association_id, { :type => 'string', :index => 'not_analyzed' }
-        mapping_for :count, { :type => 'integer' }
+        mapping_for :count,                 { :type => 'integer' }
 
         create_es_index
         create_es_mappings

--- a/spec/lib/elastic_model/integration/callbacks_with_parent_indices_spec.rb
+++ b/spec/lib/elastic_model/integration/callbacks_with_parent_indices_spec.rb
@@ -62,9 +62,9 @@ describe ElasticModel::Callbacks do
             :_routing => { :path => "parent_association_id" }
           })
 
-          mapping_for :_id, { :type => 'string', :index => 'not_analyzed' }
+          mapping_for :_id,                   { :type => 'string', :index => 'not_analyzed' }
           mapping_for :parent_association_id, { :type => 'string', :index => 'not_analyzed' }
-          mapping_for :count, { :type => 'integer' }
+          mapping_for :count,                 { :type => 'integer' }
 
           create_es_index
           create_es_mappings
@@ -89,9 +89,9 @@ describe ElasticModel::Callbacks do
             :_routing => { :path => "parent_association_id", :required => false }
           })
 
-          mapping_for :_id, { :type => 'string', :index => 'not_analyzed' }
+          mapping_for :_id,                   { :type => 'string', :index => 'not_analyzed' }
           mapping_for :parent_association_id, { :type => 'string', :index => 'not_analyzed' }
-          mapping_for :count, { :type => 'integer' }
+          mapping_for :count,                 { :type => 'integer' }
 
           create_es_index
           create_es_mappings

--- a/spec/lib/elastic_model/integration/instrumentation_spec.rb
+++ b/spec/lib/elastic_model/integration/instrumentation_spec.rb
@@ -49,9 +49,21 @@ describe ElasticModel::Instrumentation do
   end
 
   describe '.mapping_for & .create_es_mappings' do
+    before do
+      test_class.class_eval do
+        field :text_field
+        field :integer_field
+        field :indexed_text_field
+      end
+    end
+
     context 'when mapping is not existing' do
       before do
         test_class.class_eval do
+          field :text_field
+          field :integer_field
+          field :indexed_text_field
+
           mapping_for :text_field,         { :type => 'string', :index => 'not_analyzed' }
           mapping_for :integer_field,      { :type => 'integer' }
           mapping_for :indexed_text_field, { :type => 'string', :analyzer => 'snowball' }
@@ -138,6 +150,11 @@ describe ElasticModel::Instrumentation do
   describe '.save_to_es!' do
     it "saves to Elasticsearch always" do
       test_class.class_eval do
+        field :text_field
+        field :integer_field
+        field :indexed_text_field
+
+        mapping_for :_id,                { :type => 'string', :index => 'not_analyzed' }
         mapping_for :text_field,         { :type => 'string', :index => 'not_analyzed' }
         mapping_for :integer_field,      { :type => 'integer' }
         mapping_for :indexed_text_field, { :type => 'string', :analyzer => 'snowball' }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,4 +13,7 @@ RSpec.configure do |config|
   config.color = true
   config.include DefineConstantHelpers
   config.mock_with :mocha
+  config.expect_with :rspec do |c|
+    c.syntax = [:should, :expect]
+  end
 end


### PR DESCRIPTION
Add validations when creating a mapping or saving a document to ensure that mappings and fields on a document stay in sync.

There will need to be cleanup on Sieve before we can start using this version.
